### PR TITLE
Bump major version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <artifactId>r7insight_java</artifactId>
     <packaging>jar</packaging>
     <name>r7insight_java</name>
-    <version>1.1.41</version>
+    <version>3.0.0</version>
     <description>Contains logback, log4j, and log4j2 appenders that will send log data to Logentries</description>
     <url>https://github.com/rapid7/r7insight_java</url>
     <licenses>


### PR DESCRIPTION
There is already a tag for `2.0.0`, so bump to `3.0.0`:
https://github.com/rapid7/r7insight_java/releases