### PR TITLE
Increase Nexus release timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+                            <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
According to Sonatype bug reports, it can take a good bit longer than 15 minutes at times 🤷‍♂️ 